### PR TITLE
CCleaner package now adds a registry key which prevents Google Toolbar installation, fixed Ketarin job for CCleaner

### DIFF
--- a/ccleaner/ccleaner.xml
+++ b/ccleaner/ccleaner.xml
@@ -1,0 +1,140 @@
+﻿<?xml version='1.0' encoding='utf-8'?>
+<Jobs>
+  <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="6bf16cd6-589b-43b9-880d-6f5740d83227">
+    <SourceTemplate><![CDATA[<Jobs>
+  <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="0fb30714-8ed0-4611-8f1b-cb8fec9dae91">
+    <WebsiteUrl />
+    <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
+    <UserNotes />
+    <LastFileSize>384846</LastFileSize>
+    <LastFileDate>2012-05-23T02:09:37.7748325</LastFileDate>
+    <IgnoreFileInformation>false</IgnoreFileInformation>
+    <DownloadBeta>Default</DownloadBeta>
+    <DownloadDate xsi:nil="true" />
+    <CheckForUpdatesOnly>false</CheckForUpdatesOnly>
+    <VariableChangeIndicator />
+    <CanBeShared>true</CanBeShared>
+    <ShareApplication>false</ShareApplication>
+    <ExclusiveDownload>false</ExclusiveDownload>
+    <HttpReferer />
+    <SetupInstructions />
+    <Variables>
+      <item>
+        <key>
+          <string>version</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>StartEnd</VariableType>
+            <Regex />
+            <Url><placeholder name="Url with version information" value="http://www.piriform.com/ccleaner/download" /></Url>
+            <StartText>&lt;TABLE cellspacing ="1" cellpadding ="6" border = "0"&gt;
+  &lt;TR&gt;
+    &lt;TH class="Title" align="center" width=90&gt;7-Zip </StartText>
+            <EndText>&lt;BR&gt;</EndText>
+            <TextualContent />
+            <Name>version</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>url64</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <TextualContent>""</TextualContent>
+            <Name>url64</Name>
+          </UrlVariable>
+        </value>
+      </item>
+    </Variables>
+    <ExecuteCommand />
+    <ExecutePreCommand />
+    <ExecuteCommandType>Batch</ExecuteCommandType>
+    <ExecutePreCommandType>Batch</ExecutePreCommandType>
+    <Category />
+    <SourceType>FixedUrl</SourceType>
+    <DeletePreviousFile>true</DeletePreviousFile>
+    <Enabled>true</Enabled>
+    <FileHippoId />
+    <LastUpdated>2012-05-23T02:09:37.7748325</LastUpdated>
+    <TargetPath>C:\Chocolatey\_work\</TargetPath>
+    <FixedDownloadUrl><placeholder name="Download Url - Optional" value="http://download.piriform.com/{anchor1}.exe" /></FixedDownloadUrl>
+    <Name><placeholder name="Name" value="ccleaner" /></Name>
+  </ApplicationJob>
+</Jobs>]]></SourceTemplate>
+    <WebsiteUrl />
+    <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
+    <UserNotes />
+    <LastFileSize>4645232</LastFileSize>
+    <LastFileDate>2013-12-19T10:24:24+01:00</LastFileDate>
+    <IgnoreFileInformation>false</IgnoreFileInformation>
+    <DownloadBeta>Avoid</DownloadBeta>
+    <DownloadDate xsi:nil="true" />
+    <CheckForUpdatesOnly>false</CheckForUpdatesOnly>
+    <VariableChangeIndicator />
+    <CanBeShared>true</CanBeShared>
+    <ShareApplication>false</ShareApplication>
+    <ExclusiveDownload>false</ExclusiveDownload>
+    <HttpReferer />
+    <SetupInstructions />
+    <Variables>
+      <item>
+        <key>
+          <string>version</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>RegularExpression</VariableType>
+            <Regex>(?&lt;=&lt;ul class="versionHistory"&gt;\n\s+&lt;li&gt;\n\s+&lt;strong&gt;\n\s+v)[\d\.]+</Regex>
+            <Url>http://www.piriform.com/ccleaner/download</Url>
+            <StartText>&lt;ul class="versionHistory"&gt;
+        &lt;li&gt;
+          &lt;strong&gt;
+          v</StartText>
+            <EndText>
+          &lt;/strong&gt; </EndText>
+            <TextualContent />
+            <Name>version</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>anchor1</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>StartEnd</VariableType>
+            <Regex>(?&lt;=href="/downloads/)[0-9a-zA-Z. ]{1,}(?=exe)</Regex>
+            <Url>http://www.piriform.com/ccleaner/download/standard</Url>
+            <StartText>http://download.piriform.com/</StartText>
+            <EndText>.exe</EndText>
+            <Name>anchor1</Name>
+          </UrlVariable>
+        </value>
+      </item>
+    </Variables>
+    <ExecuteCommand />
+    <ExecutePreCommand />
+    <ExecuteCommandType>Batch</ExecuteCommandType>
+    <ExecutePreCommandType>Batch</ExecutePreCommandType>
+    <Category />
+    <SourceType>FixedUrl</SourceType>
+    <PreviousLocation>C:\Chocolatey\_work\ccsetup409.exe</PreviousLocation>
+    <DeletePreviousFile>true</DeletePreviousFile>
+    <Enabled>true</Enabled>
+    <FileHippoId />
+    <LastUpdated>2014-01-02T11:59:44.3368105+01:00</LastUpdated>
+    <TargetPath>C:\Chocolatey\_work\</TargetPath>
+    <FixedDownloadUrl>http://download.piriform.com/{anchor1}.exe</FixedDownloadUrl>
+    <Name>ccleaner</Name>
+  </ApplicationJob>
+</Jobs>

--- a/ccleaner/tools/regAdd.ps1
+++ b/ccleaner/tools/regAdd.ps1
@@ -1,15 +1,21 @@
-﻿# This adds a registry key which prevents Google Chrome from getting installed together with Piriform software products
+﻿# This adds a registry key which prevents Google Chrome from getting installed together with Speccy
 
 $processor = Get-WmiObject Win32_Processor
 $is64bit = $processor.AddressWidth -eq 64
 
-$regDir = 'HKLM:\SOFTWARE\Google\No Chrome Offer Until'
-$regDir64 = 'HKLM:\SOFTWARE\Wow6432Node\Google\No Chrome Offer Until'
+$regDirChrome = 'HKLM:\SOFTWARE\Google\No Chrome Offer Until'
+$regDir64Chrome = 'HKLM:\SOFTWARE\Wow6432Node\Google\No Chrome Offer Until'
+$regDirToolbar = 'HKLM:\SOFTWARE\Google\No Toolbar Offer Until'
+$regDir64Toolbar = 'HKLM:\SOFTWARE\Wow6432Node\Google\No Toolbar Offer Until'
 
 if ($is64bit) {
-    New-Item $regDir64 -ItemType directory -Force
-    New-ItemProperty -Name 'Piriform Ltd' -Path $regDir64 -PropertyType DWORD -Value 20991231 -Force
+    if (-not(Test-Path $regDir64Chrome)) {New-Item $regDir64Chrome -ItemType directory -Force}
+    New-ItemProperty -Name "Piriform Ltd" -Path $regDir64Chrome -PropertyType DWORD -Value 20991231 -Force
+    if (-not(Test-Path $regDir64Toolbar)) {New-Item $regDir64Toolbar -ItemType directory -Force}
+    New-ItemProperty -Name "Piriform Ltd" -Path $regDir64Toolbar -PropertyType DWORD -Value 20991231 -Force
 } else {
-    New-Item $regDir -ItemType directory -Force
-    New-ItemProperty -Name 'Piriform Ltd' -Path $regDir -PropertyType DWORD -Value 20991231 -Force
+    if (-not(Test-Path $regDirChrome)) {New-Item $regDirChrome -ItemType directory -Force}
+    New-ItemProperty -Name "Piriform Ltd" -Path $regDirChrome -PropertyType DWORD -Value 20991231 -Force
+    if (-not(Test-Path $regDirToolbar)) {New-Item $regDirToolbar -ItemType directory -Force}
+    New-ItemProperty -Name "Piriform Ltd" -Path $regDirToolbar -PropertyType DWORD -Value 20991231 -Force
 }


### PR DESCRIPTION
In some cases the CCleaner package automatically installed the Google Toolbar. This modification of the `regAdd.ps1` file prevents it.

The Ketarin job for CCleaner wasn’t retrieving the version of CCleaner. I added a regex to fix that.

I already pushed the updated and fixed version to the Gallery (http://chocolatey.org/packages/ccleaner), so everything you have to do is to merge this PR and import the fixed `ccleaner.xml` into Ketarin.
