### PR TITLE
Converted all *.nuspec files to UTF-8

### DIFF
--- a/advancedsystemcarefree/advancedsystemcarefree.nuspec
+++ b/advancedsystemcarefree/advancedsystemcarefree.nuspec
@@ -11,7 +11,7 @@ Advanced SystemCare 6 Free takes a one-click approach to protect, repair, clean,
 	</summary>
     <description>
 Advanced SystemCare 6 Free takes a one-click approach to protect, repair, clean, and optimize your PC.
-Why waste money on expensive "registry cleaners" to fix your PC when Advanced SystemCare Free can repair, tune up, and maintain it for you – for FREE!
+Why waste money on expensive "registry cleaners" to fix your PC when Advanced SystemCare Free can repair, tune up, and maintain it for you â€“ for FREE!
 	</description>
     <projectUrl>http://www.iobit.com/advancedsystemcareper.php#none</projectUrl>
     <tags>privacy optimization registry-cleaner cleaner</tags>

--- a/daemontoolslite/daemontoolslite.nuspec
+++ b/daemontoolslite/daemontoolslite.nuspec
@@ -14,7 +14,7 @@ DAEMON Tools Lite is an advanced application for Microsoft Windows which provide
 You can mount *.mdx, *.mds/*.mdf, *.iso, *.b5t, *.b6t, *.bwt, *.ccd, *.cdi, *.cue, *.nrg, *.pdi, *.isz disc images to a virtual drive.
 Make .iso, *.mds/*.mdf and *.mdx images of CD/DVD/Blu-ray discs.
 DAEMON Tools Pro comes with two possible licences (standard and advanced) and enables you to emulate not only CD/DVD drives but also HD DVD and Blu-ray ones.
-The maximum number of virtual drives that you can mount with images simultaneously is up to 32. DAEMON Tools Pro Advanced has a special feature for advanced users — possibility to emulate up to 4 IDE virtual devices.
+The maximum number of virtual drives that you can mount with images simultaneously is up to 32. DAEMON Tools Pro Advanced has a special feature for advanced users â€” possibility to emulate up to 4 IDE virtual devices.
 And with DAEMON Tools Net you can build centralized storage of CD, DVD, Blu-ray images and manage user access within home or business networks.
 	</description>
     <projectUrl>http://www.disc-tools.com/download/daemon</projectUrl>

--- a/gamebooster/gamebooster.nuspec
+++ b/gamebooster/gamebooster.nuspec
@@ -13,7 +13,7 @@ Designed to help optimize your PC for smoother, more responsive game play in the
 Designed to help optimize your PC for smoother, more responsive game play in the latest PC games.
 Game Booster helps achieve the performance edge previously only available to highly technical enthusiasts.
 It works by temporarily shutting down background processes, cleaning RAM, and intensifying processor performance.
-That means you can keep all the features of Microsoft Windows Vista and XP ready for when you need them, but turn them off when you are ready to get down to serious business – gaming.
+That means you can keep all the features of Microsoft Windows Vista and XP ready for when you need them, but turn them off when you are ready to get down to serious business â€“ gaming.
 	</description>
     <projectUrl>http://www.razerzone.com/gamebooster/</projectUrl>
     <tags>gaming game-boosting game-performance pc-optimization</tags>

--- a/geany/geany.nuspec
+++ b/geany/geany.nuspec
@@ -4,7 +4,7 @@
     <id>{{PackageName}}</id>
     <title>Geany</title>
     <version>{{PackageVersion}}</version>
-    <authors>Enrico Tröger, Frank Lanitz, Nick Treleaven and Dominic Hopf</authors>
+    <authors>Enrico TrÃ¶ger, Frank Lanitz, Nick Treleaven and Dominic Hopf</authors>
     <owners>tonigellida</owners>
     <summary>
 Geany is a small and lightweight Integrated Development Environment.

--- a/sonyvegaspro/sonyvegaspro.nuspec
+++ b/sonyvegaspro/sonyvegaspro.nuspec
@@ -7,11 +7,11 @@
     <authors>Sony</authors>
     <owners>tonigellida</owners>
     <summary>
-The Vegas Pro collection combines Vegas Pro, DVD Architect Pro, and Dolby® Digital AC-3 encoding software to offer an integrated environment for all phases of professional video, audio, DVD, and broadcast production.
+The Vegas Pro collection combines Vegas Pro, DVD Architect Pro, and DolbyÂ® Digital AC-3 encoding software to offer an integrated environment for all phases of professional video, audio, DVD, and broadcast production.
 	</summary>
     <description>
-The Vegas Pro collection combines Vegas Pro, DVD Architect Pro, and Dolby® Digital AC-3 encoding software to offer an integrated environment for all phases of professional video, audio, DVD, and broadcast production.
-These tools let you edit and process DV, AVCHD, HDV, SD/HD-SDI, and all XDCAM™ formats in real time, fine-tune audio with precision, and author surround sound, dual-layer DVDs.
+The Vegas Pro collection combines Vegas Pro, DVD Architect Pro, and DolbyÂ® Digital AC-3 encoding software to offer an integrated environment for all phases of professional video, audio, DVD, and broadcast production.
+These tools let you edit and process DV, AVCHD, HDV, SD/HD-SDI, and all XDCAMâ„¢ formats in real time, fine-tune audio with precision, and author surround sound, dual-layer DVDs.
 	</description>
     <projectUrl>http://www.sonycreativesoftware.com/download/trials/vegaspro</projectUrl>
     <tags>trial-version notUninstallable video-editing dvd-authoring</tags>

--- a/systemninja/systemninja.nuspec
+++ b/systemninja/systemninja.nuspec
@@ -11,7 +11,7 @@ System Ninja is a fast, powerful and effective system optimization solution for 
 	</summary>
     <description>
 System Ninja is a fast, powerful and effective system optimization solution for Windows XP, Windows Vista and Windows 7.
-It’s designed to quickly remove junk files, improve system speed and help fix problems.
+Itâ€™s designed to quickly remove junk files, improve system speed and help fix problems.
 	</description>
     <projectUrl>http://singularlabs.com/software/system-ninja/</projectUrl>
     <tags>cleaner</tags>


### PR DESCRIPTION
*.nuspec files should be saved as UTF-8, because the Chocolatey Gallery also uses that character encoding. Otherwise it will show all characters outside the ASCII range incorrectly, such as `™, –, ö and ’`. For example, look at this package page: http://chocolatey.org/packages/sonyvegaspro. As you can see there are question marks (�) instead of the correct characters, because your nuspec files weren’t saved as UTF-8.

So remember to set the default character encoding of your editor to UTF-8 (without BOM to be more precise). Then you won’t have this problem any longer. I also recommend to read this section: https://github.com/chocolatey/chocolatey/wiki/CreatePackages#character-encoding

Note that in the diff shows some weird characters, but that’s only because of a representation bug of GitHub. I can confirm that these are the correct characters. Click on the “View” button of a file and you will see that they are the correct characters.

Sorry, I know that the world of character encodings is really confusing (mostly thanks to :trollface: Microsoft). Ask me if something is unclear, otherwise feel free to merge this. :smiley: 
